### PR TITLE
feat(docs): Add README hub for OctoAcme Project Management Docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,132 @@
+# OctoAcme Project Management Documentation
+
+This README provides an overview and central index for all OctoAcme project management process documentation. Use this as your entry point to understand how OctoAcme runs projects, manages risks, and delivers value.
+
+---
+
+## OctoAcme Project Management Overview
+
+OctoAcme employs a structured, iterative, and quality-focused approach to project management. Our methodology ensures all work is purposeful, well-scoped, aligned across teams, and continuously improving.
+
+### Core Principles
+- **Customer-first**: Prioritize customer value and usability
+- **Iterative delivery**: Deliver small, testable increments
+- **Clear ownership**: Each project has named Project Manager and Product Lead
+- **Data-informed decisions**: Measure impact and iterate based on evidence
+- **Psychological safety**: Encourage feedback and learning
+
+### Five-Phase Project Lifecycle
+
+**1. Initiation** — Validate business need and align stakeholders
+- Create a lightweight Project One-pager (problem, goals, success metrics, stakeholders)
+- Define initial timeline and resource needs
+- Go/no-go decision for planning
+
+**2. Planning** — Break work into actionable increments
+- Conduct stakeholder kickoff meeting
+- Create prioritized, estimated backlog with acceptance criteria
+- Define Definition of Done (DoD)
+- Identify dependencies, risks, and integration points
+- Establish release plan and milestone map
+
+**3. Execution & Tracking** — Build, test, and iterate
+- Operate in sprints with daily standups (15 min), weekly delivery syncs, and sprint reviews
+- Use GitHub Project boards: Backlog → Ready → In Progress → In Review → QA → Done
+- Small PRs (≤400 lines) with CI checks, code review, and one approval before merge
+- Embed quality: unit tests, integration tests, smoke tests, security scanning
+- Track velocity, burndown, and success metrics
+- Tiered blocker escalation: Level 1 (standup) → Level 2 (PM/Product Lead) → Level 3 (Sponsor)
+
+**4. Release & Deployment** — Deploy with confidence
+- Verify all acceptance criteria met and CI/security scans passing
+- Staged deployment: test in staging, then production
+- Release checklist: backup, smoke tests, post-deploy verification, stakeholder announcement
+- Documented rollback and incident playbook
+
+**5. Close & Retrospective** — Capture learnings and improve
+- Hold retrospectives after each sprint, release, or milestone
+- Document: what went well, what could improve, action items
+- Track improvements in backlog with clear owners and timelines
+- Measure impact and celebrate progress
+
+### Key Roles & Personas
+
+- **Developers**: Implement features, write tests, collaborate on design, identify technical risks
+- **Product Managers**: Define what to build, prioritize backlog, measure outcomes, drive customer value
+- **Project Managers**: Coordinate execution, manage schedules, handle risks, ensure transparency
+- **QA/Testing**: Validate quality, confirm acceptance criteria, ensure readiness for release
+- **Stakeholders**: Provide input, approve decisions, receive regular updates
+
+### Communication Cadence
+
+- **Daily**: 15-min standups (team focus on progress/blockers)
+- **Weekly**: PM + Product Manager sync, delivery team standup, risk review
+- **Monthly**: Stakeholder updates
+- **Ad-hoc**: Escalations and incident response
+
+### Quality & Testing Built-In
+
+- Unit tests for new logic
+- Integration tests where applicable
+- End-to-end smoke tests for critical flows
+- Security scanning in CI
+- Manual QA for feature acceptance
+- Pre-release verification before production deployment
+
+---
+
+## Process Documentation Index
+
+**Start here** if you're new to OctoAcme project management:
+
+1. **[Project Management Overview](octoacme-project-management-overview.md)** — High-level introduction to OctoAcme's approach, principles, roles, and key artifacts
+
+2. **[Project Initiation Guide](octoacme-project-initiation.md)** — Steps to validate business need, align stakeholders, and create a Project One-pager; includes the decision gate for moving to planning
+
+3. **[Project Planning](octoacme-project-planning.md)** — How to turn an approved initiative into an actionable plan: backlog creation, estimation, risk management, release planning, and Definition of Done
+
+4. **[Execution & Tracking](octoacme-execution-and-tracking.md)** — Day-to-day guidance: team rhythm (standups, syncs, demos), GitHub Project workflow, PR practices, testing, reporting, and blocker escalation
+
+5. **[Risk Management & Communication](octoacme-risks-and-communication.md)** — How to identify, assess, and mitigate risks; stakeholder communication templates; escalation paths for blockers and incidents
+
+6. **[Release & Deployment Guide](octoacme-release-and-deployment.md)** — Standardized release process: pre-release checklist, deployment workflow, rollback procedures, and release notes template
+
+7. **[Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)** — How to run effective retrospectives, track action items, and build a culture of continuous improvement
+
+8. **[Roles & Personas](octoacme-roles-and-personas.md)** — Detailed descriptions of Developers, Product Managers, Project Managers, and Stakeholder responsibilities and goals
+
+---
+
+## How to Use This Documentation
+
+### For New Team Members
+1. Start with the [Project Management Overview](octoacme-project-management-overview.md) for context
+2. Read the role definition in [Roles & Personas](octoacme-roles-and-personas.md) that matches your position
+3. Bookmark this README for quick reference
+
+### For Project Leads & PMs
+1. Use [Project Initiation Guide](octoacme-project-initiation.md) to kick off new work
+2. Reference [Project Planning](octoacme-project-planning.md) to structure delivery
+3. Review [Risk Management & Communication](octoacme-risks-and-communication.md) for stakeholder alignment
+4. Leverage [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md) after milestones
+
+### For Delivery Teams
+1. Follow the workflow described in [Execution & Tracking](octoacme-execution-and-tracking.md) during sprints
+2. Check [Release & Deployment Guide](octoacme-release-and-deployment.md) before releasing to production
+3. Contribute to retrospectives using guidance from [Retrospective & Continuous Improvement](octoacme-retrospective-and-continuous-improvement.md)
+
+### For Updates & Contributions
+See the [issue template](.github/ISSUE_TEMPLATE/add-update-content-to-process-docs.yml) to propose updates to these docs.
+
+---
+
+## Purpose of This Knowledge Base
+
+This documentation serves as:
+- **Single source of truth** for OctoAcme project management processes
+- **Onboarding accelerator** for new team members
+- **Reference guide** for consistent, repeatable execution
+- **Living artifact** that evolves with team feedback and learnings
+- **Knowledge preservation** to reduce single-person dependency
+
+All team members are encouraged to contribute improvements and refinements through the issue template.


### PR DESCRIPTION
## Overview
Adds a central README hub in the `docs/` folder to serve as the entry point for all OctoAcme project management process documentation.

## What's included
- Comprehensive overview of OctoAcme's 5-phase project lifecycle
- Core principles, roles, and communication cadence
- Quality and testing practices
- Direct links to all 8 process documentation files
- Usage guidance by role (new team members, PMs, delivery teams)

## Closes
Closes #2

## Reviewers
@19121A1228

## Acceptance Criteria
- [x] Content aligns with existing process docs
- [x] README improves clarity and closes the documentation gap
- [x] Links to all 8 process docs are functional